### PR TITLE
Add object accessor `Identifier` variant

### DIFF
--- a/src/Cherry/Data/AST.elm
+++ b/src/Cherry/Data/AST.elm
@@ -65,6 +65,7 @@ type Identifier
     = Local String
     | Scoped (List String) String
     | Operator Operator
+    | ObjectField String
 
 {-| -}
 type Operator

--- a/src/Cherry/Stage/Emit/JSON/Expression/Identifier.elm
+++ b/src/Cherry/Stage/Emit/JSON/Expression/Identifier.elm
@@ -28,6 +28,9 @@ emit identifier =
         AST.Operator op ->
             operatorEmitter op
 
+        AST.ObjectField fieldName ->
+            objectFieldEmitter fieldName
+
 {-| -}
 localEmitter : String -> Json.Encode.Value
 localEmitter name =
@@ -50,3 +53,8 @@ operatorEmitter op =
         [ ( "op", Operator.emit op )
         ]
 
+objectFieldEmitter : String -> Json.Encode.Value
+objectFieldEmitter fieldName =
+    Json.Encode.Extra.taggedObject "AST.Identifier.ObjectField"
+        [ ( "fieldName", Json.Encode.string fieldName )
+        ]

--- a/src/Cherry/Stage/Emit/JavaScript/Expression/Identifier.elm
+++ b/src/Cherry/Stage/Emit/JavaScript/Expression/Identifier.elm
@@ -25,6 +25,9 @@ emit identifier =
         AST.Operator op ->
             operatorEmitter op
 
+        AST.ObjectField fieldName ->
+            objectFieldEmitter fieldName
+
 {-| -}
 localEmitter : String -> String
 localEmitter name =
@@ -97,3 +100,9 @@ operatorEmitter op =
 
         AST.Join ->
             "($x) => ($y) => ([ ...$x, ...$y ])"
+
+{-| -}
+objectFieldEmitter : String -> String
+objectFieldEmitter fieldName =
+    "($x) => $x.{fieldName}"
+        |> String.replace "{fieldName}" fieldName

--- a/src/Cherry/Stage/Parse/Expression/Identifier.elm
+++ b/src/Cherry/Stage/Parse/Expression/Identifier.elm
@@ -1,6 +1,6 @@
 module Cherry.Stage.Parse.Expression.Identifier exposing 
     ( parser
-    , nameParser, namespaceParser
+    , nameParser, namespaceParser, objectFieldParser
     )
 
 
@@ -24,6 +24,7 @@ parser =
         [ localParser
         , scopedParser
         , Operator.asIdentifierParser
+        , objectFieldParser
         ]
 
 {-| -}
@@ -68,3 +69,10 @@ namespaceParser =
         , inner = Char.isAlphaNum
         , reserved = Set.empty
         }
+
+{-| -}
+objectFieldParser : Parser AST.Identifier
+objectFieldParser =
+    Parser.succeed AST.ObjectField
+     |. Parser.symbol "."
+     |= nameParser

--- a/src/Cherry/Stage/Parse/Expression/Identifier.elm
+++ b/src/Cherry/Stage/Parse/Expression/Identifier.elm
@@ -1,6 +1,6 @@
 module Cherry.Stage.Parse.Expression.Identifier exposing 
     ( parser
-    , nameParser, namespaceParser, objectFieldParser
+    , nameParser, namespaceParser
     )
 
 
@@ -74,5 +74,5 @@ namespaceParser =
 objectFieldParser : Parser AST.Identifier
 objectFieldParser =
     Parser.succeed AST.ObjectField
-     |. Parser.symbol "."
-     |= nameParser
+        |. Parser.symbol "."
+        |= nameParser


### PR DESCRIPTION
This adds support for parsing object accessors as identifiers, enabling
use of them as functions, e.g. `.key obj === obj.key`.

Closes #13.