### PR TITLE
✨ Add support for wildcard patterns.

### DIFF
--- a/src/Cherry/Data/AST.elm
+++ b/src/Cherry/Data/AST.elm
@@ -85,6 +85,7 @@ type Pattern
     | Name String
     | ObjectDestructure (List ( String, Maybe Pattern ))
     | Value Literal
+    | Wildcard (Maybe String)
 
 {-| -}
 type Literal

--- a/src/Cherry/Stage/Emit/JSON/Expression/Pattern.elm
+++ b/src/Cherry/Stage/Emit/JSON/Expression/Pattern.elm
@@ -31,6 +31,9 @@ emit emitExpression pattern =
         AST.Value literal ->
             valueEmitter emitExpression literal
 
+        AST.Wildcard name ->
+            wildcardEmitter name
+
 {-| -}
 arrayDestructureEmitter : (AST.Expression -> Json.Encode.Value) -> List AST.Pattern -> Json.Encode.Value
 arrayDestructureEmitter emitExpression patterns =
@@ -74,3 +77,15 @@ valueEmitter emitExpression literal =
         [ ( "literal", Literal.emit emitExpression literal )
         ]
 
+{-| -}
+wildcardEmitter : Maybe String -> Json.Encode.Value
+wildcardEmitter name =
+    case name of
+        Just n ->
+            Json.Encode.Extra.taggedObject "AST.Pattern.Wildcard"
+                [ ( "name", Json.Encode.string n ) 
+                ]
+
+        Nothing ->
+            Json.Encode.Extra.taggedObject "AST.Pattern.Wildcard" 
+                []

--- a/src/Cherry/Stage/Emit/JavaScript/Expression/Pattern.elm
+++ b/src/Cherry/Stage/Emit/JavaScript/Expression/Pattern.elm
@@ -29,6 +29,9 @@ emit emitExpression pattern =
         AST.Value literal ->
             valueEmitter emitExpression literal
 
+        AST.Wildcard name ->
+            wildcardEmitter name
+
 {-| -}
 arrayDestructureEmitter : (AST.Expression -> String) -> List AST.Pattern -> String
 arrayDestructureEmitter emitExpression patterns =
@@ -63,3 +66,8 @@ valueEmitter : (AST.Expression -> String) -> AST.Literal -> String
 valueEmitter emitExpression literal =
     Literal.emit emitExpression literal
 
+{-| -}
+wildcardEmitter : Maybe String -> String
+wildcardEmitter name =
+    "_{name}"
+        |> String.replace "{name}" (Maybe.withDefault "" name)

--- a/src/Cherry/Stage/Parse/Expression/Pattern.elm
+++ b/src/Cherry/Stage/Parse/Expression/Pattern.elm
@@ -20,6 +20,7 @@ parser =
         , nameParser
         , objectDestructureParser
         , valueParser
+        , wildcardParser
         ]
 
 arrayDestructureParser : Parser AST.Pattern
@@ -65,3 +66,14 @@ valueParser : Parser AST.Pattern
 valueParser =
     Parser.succeed AST.Value
         |= Literal.primitiveParser
+
+{-| -}
+wildcardParser : Parser AST.Pattern
+wildcardParser =
+    Parser.succeed AST.Wildcard
+        |. Parser.symbol "_"
+        |= Parser.oneOf
+            [ Parser.succeed Just
+                |= Identifier.nameParser
+            , Parser.succeed Nothing
+            ]


### PR DESCRIPTION
Adds support for wildcard/ignored patterns such as `_` or `_foo`. The trailing name is useful because you can effectively comment ignored bindings. As a simple example consider:
```
fun always = keep _ignore => keep
```
Here's another example using the (currently not-implemented) `switch` syntax:
```
switch ast on
    | AST.Application _function args => // do something with just `args` here
    | _ => // do something else
```

Closes #8.