### PR TITLE
✨ Add parsing for object literal shorthand syntax.

### DIFF
--- a/src/Cherry/Stage/Parse/Expression/Literal.elm
+++ b/src/Cherry/Stage/Parse/Expression/Literal.elm
@@ -100,12 +100,17 @@ objectParser expressionParser =
             , separator = ","
             , end = "}"
             , item = 
-                Parser.succeed Tuple.pair
-                    |= Identifier.nameParser
-                    |. Parser.spaces
-                    |. Parser.symbol ":"
-                    |. Parser.spaces
-                    |= expressionParser
+                Parser.oneOf
+                    [ Parser.succeed Tuple.pair
+                        |= Identifier.nameParser
+                        |. Parser.spaces
+                        |. Parser.symbol ":"
+                        |. Parser.spaces
+                        |= expressionParser
+                        |> Parser.backtrackable
+                    , Parser.succeed (\name -> ( name , AST.Identifier (AST.Local name) ))
+                        |= Identifier.nameParser
+                    ]
             , spaces = Parser.spaces
             , trailing = Parser.Forbidden
             }


### PR DESCRIPTION
Now we can parse things like `{ x: 10, y, z }` and the AST treats this as though you'd written `{ x: 10, y: y, z: z }`.

Closes #11.