### PR TITLE
✨ Support patterns in `where` binding assignment.

### DIFF
--- a/src/Cherry/Data/AST.elm
+++ b/src/Cherry/Data/AST.elm
@@ -37,7 +37,7 @@ type Visibility
 
 {-| -}
 type alias Binding =
-    { name : String
+    { name : Pattern
     , body : Expression
     }
 

--- a/src/Cherry/Stage/Emit/JSON/Declaration.elm
+++ b/src/Cherry/Stage/Emit/JSON/Declaration.elm
@@ -69,6 +69,6 @@ visibilityEmitter visibility =
 bindingEmitter : AST.Binding -> Json.Encode.Value
 bindingEmitter { name, body } =
     Json.Encode.Extra.taggedObject "AST.Binding"
-        [ ( "name", Json.Encode.string name )
+        [ ( "name", Pattern.emit Expression.emit name )
         , ( "body", Expression.emit body )
         ]

--- a/src/Cherry/Stage/Emit/JavaScript/Declaration.elm
+++ b/src/Cherry/Stage/Emit/JavaScript/Declaration.elm
@@ -109,7 +109,7 @@ bindingsEmitter bindings =
 bindingEmitter : AST.Binding -> String
 bindingEmitter { name, body } =
     "var {name} = {body};"
-        |> String.replace "{name}" name
+        |> String.replace "{name}" (Pattern.emit Expression.emit name)
         |> String.replace "{body}" (Expression.emit body)
 
 

--- a/src/Cherry/Stage/Parse/Declaration.elm
+++ b/src/Cherry/Stage/Parse/Declaration.elm
@@ -130,7 +130,7 @@ bindingParser : Parser AST.Binding
 bindingParser =
     Parser.succeed AST.Binding
         |. Parser.spaces
-        |= Identifier.nameParser
+        |= Pattern.parser
         |. Parser.Extra.spaces
         |. Parser.symbol "="
         |. Parser.spaces


### PR DESCRIPTION
Now you can do things like
```
fun foo = x => x + y * z
    where
        { y } = obj
        [ z ] = arr
```

Closes #10.