### PR TITLE
Add support for double-quoted string literals

### DIFF
--- a/src/Cherry/Stage/Parse/Expression/Literal.elm
+++ b/src/Cherry/Stage/Parse/Expression/Literal.elm
@@ -123,4 +123,7 @@ objectParser expressionParser =
 stringParser : Parser AST.Literal
 stringParser =
     Parser.succeed AST.String
-        |= Parser.Extra.string '\''
+        |= Parser.oneOf
+            [ Parser.Extra.string '"'
+            , Parser.Extra.string '\''
+            ]


### PR DESCRIPTION
This enables parsing string literals in the format `"string here"`.
